### PR TITLE
Adds backgroundSize property to ensure images cover entire page

### DIFF
--- a/src/Ikigai.js
+++ b/src/Ikigai.js
@@ -349,6 +349,7 @@ export class Ikigai extends Component {
           }
         : {
             background: `url(${image}) no-repeat center center`,
+            backgroundSize: "cover",
             filter,
           };
 


### PR DESCRIPTION
## Description

I really enjoy this minimal New Tab experience! :)
After switching to a larger screen, I noticed that the image is staying centered and not covering the whole page.

This PR should fix that.

This is how it looked before:

![Screenshot 2022-01-19 at 09 55 21](https://user-images.githubusercontent.com/3296643/150099541-d5a8db0c-d5d1-4592-a510-311ff3ccd53f.png)


And after:
![Screenshot 2022-01-19 at 10 10 48](https://user-images.githubusercontent.com/3296643/150099489-a6b37aa2-0079-4582-bb0a-adaad39bd287.png)

