### PR TITLE
Cycle "Every Day" at midnight, not every 24 hrs

### DIFF
--- a/src/Ikigai.js
+++ b/src/Ikigai.js
@@ -245,6 +245,10 @@ export class Ikigai extends Component {
         localStorage.getItem("background_last_updated")
       );
 
+      if (background_update_freq == 86400) {
+        background_last_updated = new Date(background_last_updated * 1000).setHours(0,0,0,0)/1000;
+      }
+
       console.log(
         `Next Background change at ${this.unixToHumanTime(
           background_update_freq + background_last_updated

--- a/src/Ikigai.js
+++ b/src/Ikigai.js
@@ -149,6 +149,10 @@ export class Ikigai extends Component {
         let time_now = Math.round(new Date().getTime() / 1000);
         let background_update_freq = parseInt(this.state.background_cycle);
 
+        if (background_update_freq == 86400) {
+          background_last_updated = new Date(background_last_updated * 1000).setHours(0,0,0,0)/1000;
+        }
+
         if (background_last_updated + background_update_freq <= time_now) {
           this.refetchAndSetImageHidden();
           let time_now = Math.round(new Date().getTime() / 1000);


### PR DESCRIPTION
If "Cycle Background" is set to "Every Day," this makes it cycle every midnight rather than every 24 hours. It was a little strange to have the wallpaper changing at like 6PM every day, because that's when I first installed the extension.